### PR TITLE
Schemas-proposal som arbeidsmappe

### DIFF
--- a/schemas-proposal/commonEvents.js
+++ b/schemas-proposal/commonEvents.js
@@ -1,6 +1,6 @@
 export default {
   title: 'Aktiviteter',
-  name: 'events',
+  name: 'commonEvents',
   type: 'document',
   fields: [
     {
@@ -8,7 +8,7 @@ export default {
       name: 'name',
       type: 'string',
       description: 'Navn på denne aktiviteten, e.g; møte, samling eller fritidsaktivitet',
-      validation: rule => rule.required().min(10).max(30)
-    }
-  ]
+      validation: (rule) => rule.required().min(10).max(30),
+    },
+  ],
 }

--- a/schemas-proposal/index.js
+++ b/schemas-proposal/index.js
@@ -1,0 +1,7 @@
+import commonEvents from './commonEvents'
+import hikingRoutes from './hikingRoutes'
+import menuCoffe from './menuCoffee'
+import menuLunch from './menuLunch'
+import schedule from './schedule'
+
+export const schemaTypes = [commonEvents, hikingRoutes, menuCoffe, menuLunch, schedule]

--- a/schemas-proposal/schedule.js
+++ b/schemas-proposal/schedule.js
@@ -9,19 +9,21 @@ export default {
       type: 'string',
       options: {
         list: [
-          { title: 'Frokost', value: 'breakfast' },
-          { title: 'Lunch', value: 'lunch' },
-          { title: 'Middag', value: 'dinner' },
-          { title: 'Møte', value: 'meeting' },
-          { title: 'Tur', value: 'hike' },
-          { title: 'Annen aktivitet', value: 'activity' }
-        ]
-      }
-    },{
+          {title: 'Frokost', value: 'breakfast'},
+          {title: 'Lunch', value: 'lunch'},
+          {title: 'Middag', value: 'dinner'},
+          {title: 'Møte', value: 'meeting'},
+          {title: 'Tur', value: 'hike'},
+          {title: 'Annen aktivitet', value: 'activity'},
+        ],
+      },
+    },
+    {
       title: 'Dato',
       name: 'date',
-      type: 'datetime'
-    },{
+      type: 'datetime',
+    },
+    {
       title: 'Søk etter...',
       name: 'ref',
       type: 'object',
@@ -30,22 +32,24 @@ export default {
           title: 'Lunsj-rett',
           name: 'lunch',
           type: 'reference',
-          to: [{ type: 'menuLunch' }],
-          hidden: ({ document }) => document?.name !== 'lunch'
-        },{
+          to: [{type: 'menuLunch'}],
+          hidden: ({document}) => document?.name !== 'lunch',
+        },
+        {
           title: 'Tur',
           name: 'hike',
           type: 'reference',
-          to: [{ type: 'hikingRoutes' }],
-          hidden: ({ document }) => document?.name !== 'hike'
-        },{
+          to: [{type: 'routes'}],
+          hidden: ({document}) => document?.name !== 'hike',
+        },
+        {
           title: 'Aktivitet',
           name: 'activity',
           type: 'reference',
-          to: [{ type: 'events' }],
-          hidden: ({ document }) => document?.name !== 'activity'
-        }
-      ]
-    }
-  ]
+          to: [{type: 'events'}],
+          hidden: ({document}) => document?.name !== 'activity',
+        },
+      ],
+    },
+  ],
 }

--- a/schemas/index.js
+++ b/schemas/index.js
@@ -1,19 +1,10 @@
-import ahead from "./ahead"
-import kafe from "./kafe"
-import hiking from "./hiking"
-import lunch from "./lunch"
+import ahead from './ahead'
+import kafe from './kafe'
+import hiking from './hiking'
+import lunch from './lunch'
 import schedule from './schedule'
 import imagepages from './imagepages'
 import onboarding from './onboarding'
 import images from './imageNew'
 
-export const schemaTypes = [
-  lunch,
-  schedule,
-  imagepages,
-  ahead,
-  kafe,
-  hiking,
-  onboarding,
-  images
-  ]
+export const schemaTypes = [lunch, schedule, imagepages, ahead, kafe, hiking, onboarding, images]


### PR DESCRIPTION
Added index.js til schemas proposal slik at vi kan jobbe med ny schema i local sanity uten å touche gammel  schema. Sanity booter uten errors via schema-proposals. Hvis man endrer navn på de to mappene, evt endrer hva navn som skal brukes i sanity sin config fil, så slipper man å flytte rundt på filer for å jobbe med de. Måtte endre bittelitt på navn som ga konflikter i sanity.